### PR TITLE
Allow functions to be passed in `ignore` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function search(tree, options, handler) {
   }
 
   ignore = ignore.map(function (x) {
-    if (typeof x === 'object') return x
+    if (typeof x !== 'string') return x
     return {tagName: x}
   })
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var visit = require('unist-util-visit-parents')
-var is = require('hast-util-is-element')
+var is = require('unist-util-is')
 var escape = require('escape-string-regexp')
 
 var defaultIgnore = ['title', 'script', 'style', 'svg', 'math']
@@ -119,6 +119,14 @@ function findAndReplace(tree, find, replace, options) {
 function search(tree, options, handler) {
   var ignore = options.ignore || defaultIgnore
   var result = []
+  if (!Array.isArray(ignore)) {
+    ignore = [ignore]
+  }
+
+  ignore = ignore.map(function (x) {
+    if (typeof x === 'object') return x
+    return {tagName: x}
+  })
 
   visit(tree, 'text', visitor)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "escape-string-regexp": "^2.0.0",
-    "hast-util-is-element": "^1.0.0",
+    "unist-util-is": "4.0.2",
     "unist-util-visit-parents": "^3.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -167,6 +167,48 @@ test('findAndReplace', function (t) {
   )
 
   t.deepEqual(
+    findAndReplace(
+      h('p', [
+        h('span', 'visible text'),
+        h('span', {
+          text: 'hidden text',
+          style: 'font-size:1px;display:none;line-height:1px;'
+        })
+      ]),
+      'text',
+      'TEXT',
+      {
+        ignore: function (node) {
+          return /display:\s*none/.test(node.properties.style)
+        }
+      }
+    ),
+    h('p', [
+      h('span', ['visible ', 'TEXT']),
+      h('span', {
+        text: 'hidden text',
+        style: 'font-size:1px;display:none;line-height:1px;'
+      })
+    ]),
+    'should ignore using function'
+  )
+
+  t.deepEqual(
+    findAndReplace(
+      h('p', [h('span', 'text'), h('sup', 'text')]),
+      'text',
+      'TEXT',
+      {
+        ignore: {
+          tagName: 'sup'
+        }
+      }
+    ),
+    h('p', [h('span', 'TEXT'), h('sup', 'text')]),
+    'should ignore using objects'
+  )
+
+  t.deepEqual(
     findAndReplace(h('p', 'Some emphasis, importance, and code.'), {
       importance: function (match) {
         return h('strong', match)


### PR DESCRIPTION
Addresses https://github.com/syntax-tree/hast-util-find-and-replace/issues/1

I would like to be able to tell findAndReplace to ignore certain nodes if they contain a class (like `<p class="skip-me"/>`), or if their style includes some css property

This PR switches to use unist-util-is, which already handles that